### PR TITLE
Add VectorElement support

### DIFF
--- a/prototypyside/models/component_template.py
+++ b/prototypyside/models/component_template.py
@@ -438,6 +438,9 @@ class ComponentTemplate(QGraphicsObject):
                 el = ImageElement.from_dict(e, registry=registry, is_clone=is_clone)
             elif prefix == "te":
                 el = TextElement.from_dict(e, registry=registry, is_clone=is_clone)
+            elif prefix == "ve":
+                from prototypyside.models.vector_element import VectorElement
+                el = VectorElement.from_dict(e, registry=registry, is_clone=is_clone)
             else:
                 raise ValueError(f"Unknown prefix {prefix}")
             inst.add_item(el)

--- a/prototypyside/models/vector_element.py
+++ b/prototypyside/models/vector_element.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from PySide6.QtCore import Qt, QPointF, QRectF
+from PySide6.QtGui import QPainter, QPen
+from PySide6.QtSvg import QSvgRenderer
+from PySide6.QtWidgets import QGraphicsSceneDragDropEvent, QGraphicsObject, QFileDialog
+
+from prototypyside.models.component_element import ComponentElement
+from prototypyside.utils.units.unit_str_geometry import UnitStrGeometry
+
+
+class VectorElement(ComponentElement):
+    """A component element that renders SVG vector graphics."""
+
+    def __init__(self, pid, geometry: UnitStrGeometry, tpid=None,
+                 parent: Optional[QGraphicsObject] = None, name: str = None):
+        super().__init__(pid, geometry, tpid, parent, name)
+        self._renderer: Optional[QSvgRenderer] = None
+        self.showPlaceholderText = True
+        self.setAcceptDrops(True)
+
+    # Override content so it loads the SVG file
+    @property
+    def content(self):
+        return self._content
+
+    @content.setter
+    def content(self, new_content: Optional[str]):
+        if not new_content or not Path(new_content).exists():
+            self._renderer = None
+            self._content = None
+        else:
+            renderer = QSvgRenderer(new_content)
+            if renderer.isValid():
+                self._renderer = renderer
+                self._content = new_content
+            else:
+                self._renderer = None
+                self._content = None
+        self.item_changed.emit()
+        self.update()
+
+    def paint(self, painter: QPainter, option, widget=None):
+        rect = self.geometry.to("px", dpi=self.dpi).rect
+        if self._renderer:
+            self._renderer.render(painter, rect)
+        elif self.showPlaceholderText:
+            painter.save()
+            painter.setPen(QPen(Qt.darkGray))
+            font = painter.font()
+            font.setPointSize(10)
+            font.setItalic(True)
+            painter.setFont(font)
+            painter.drawText(rect, self.alignment_flags,
+                             "Drop SVG\nor Double Click to Set")
+            painter.restore()
+        super().paint(painter, option, widget)
+
+    # --- Drag and drop / double click ---
+    def dragEnterEvent(self, event: QGraphicsSceneDragDropEvent):
+        if event.mimeData().hasUrls():
+            event.acceptProposedAction()
+
+    def dropEvent(self, event: QGraphicsSceneDragDropEvent):
+        if event.mimeData().hasUrls():
+            url = event.mimeData().urls()[0]
+            file_path = url.toLocalFile()
+            if file_path.lower().endswith(".svg"):
+                self.content = file_path
+            event.acceptProposedAction()
+
+    def mouseDoubleClickEvent(self, event):
+        path, _ = QFileDialog.getOpenFileName(None, "Select SVG", "", "SVG Files (*.svg)")
+        if path:
+            self.content = path

--- a/prototypyside/schemas/component.json
+++ b/prototypyside/schemas/component.json
@@ -25,7 +25,8 @@
       "items": {
         "oneOf":[
           { "$ref": "text_element.json" },
-          { "$ref": "image_element.json" }
+          { "$ref": "image_element.json" },
+          { "$ref": "vector_element.json" }
         ]
       },
       "description": "List of TextElement or ImageElement objects"

--- a/prototypyside/schemas/component_template.json
+++ b/prototypyside/schemas/component_template.json
@@ -24,7 +24,8 @@
       "items": {
         "oneOf":[
           { "$ref": "text_element.json" },
-          { "$ref": "image_element.json" }
+          { "$ref": "image_element.json" },
+          { "$ref": "vector_element.json" }
         ]
       },
       "description": "List of TextElement or ImageElement objects"

--- a/prototypyside/schemas/vector_element.json
+++ b/prototypyside/schemas/vector_element.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "vector_element.json",
+  "title": "VectorElement",
+  "type": "object",
+  "properties": {
+    "pid": { "type": "string" },
+    "geometry": { "$ref": "unit_str_geometry.json" },
+    "tpid": { "type": ["string", "null"] },
+    "name": { "type": ["string", "null"] },
+    "z_order": { "type": "integer" },
+    "color": { "type": "integer" },
+    "bg_color": { "type": "integer" },
+    "border_color": { "type": "integer" },
+    "border_width": { "$ref": "unit_str.json" },
+    "alignment": { "type": "string" },
+    "content": { "type": "string" }
+  },
+  "required": [
+    "alignment", "bg_color", "border_color", "border_width", "color",
+    "content", "geometry", "name", "pid", "tpid", "z_order"
+  ],
+  "additionalProperties": false
+}

--- a/prototypyside/services/export_manager.py
+++ b/prototypyside/services/export_manager.py
@@ -3,6 +3,7 @@ from PySide6.QtCore import QSizeF
 from PySide6.QtGui  import QPainter, QPdfWriter, QImage, QPageSize, QPageLayout, QStyleOptionGraphicsItem
 from PySide6.QtWidgets import QGraphicsScene
 from prototypyside.models.text_element import TextElement
+from prototypyside.models.vector_element import VectorElement
 from prototypyside.utils.units.unit_str_geometry import UnitStrGeometry
 from PySide6.QtCore import Qt, QSizeF, QRectF, QMarginsF
 from pathlib import Path
@@ -141,6 +142,7 @@ class ExportManager:
             page.dpi = self.settings.print_dpi
             for slot in page.slots:
                 slot.render_text = False
+                slot.render_vector = False
 
             page.invalidate_cache()
             img = page.image
@@ -154,7 +156,7 @@ class ExportManager:
             target_rect = QRectF(0, 0, page_size_pt.width(), page_size_pt.height())
             painter.drawImage(target_rect, img)
 
-            # Overlay text elements as vector graphics
+            # Overlay text and vector elements as vector graphics
             for slot in page.slots:
                 if not slot.content:
                     continue
@@ -163,7 +165,7 @@ class ExportManager:
                 painter.scale(scale_pt_per_px, scale_pt_per_px)
                 painter.translate(slot_pos)
                 for item in slot.content.items:
-                    if isinstance(item, TextElement):
+                    if isinstance(item, (TextElement, VectorElement)):
                         painter.save()
                         painter.translate(item.pos())
                         bounds = item.boundingRect()

--- a/prototypyside/services/proto_factory.py
+++ b/prototypyside/services/proto_factory.py
@@ -7,6 +7,7 @@ from prototypyside.models.component_template import ComponentTemplate
 from prototypyside.models.component_element import ComponentElement
 from prototypyside.models.text_element import TextElement
 from prototypyside.models.image_element import ImageElement
+from prototypyside.models.vector_element import VectorElement
 from prototypyside.models.layout_template import LayoutTemplate
 from prototypyside.models.layout_slot import LayoutSlot
 from prototypyside.utils.units.unit_str_geometry import UnitStrGeometry
@@ -33,6 +34,7 @@ class ProtoFactory:
     _PROTO_OBJECT_CLASSES: Dict[str, Type] = {
         "te": TextElement,
         "ie": ImageElement,
+        "ve": VectorElement,
         "ct": ComponentTemplate,
         "cc": ComponentTemplate,
         "lt": LayoutTemplate,

--- a/prototypyside/services/proto_registry.py
+++ b/prototypyside/services/proto_registry.py
@@ -22,6 +22,7 @@ from prototypyside.views.overlays.incremental_grid import IncrementalGrid
 BASE_NAMES = {
     "ie": "Image Element",
     "te": "Text Element",
+    "ve": "Vector Element",
     "ct": "Component Template",
     "cc": "Component",
     "lt": "Layout Template",

--- a/prototypyside/tests/test_serialization_roundtrip.py
+++ b/prototypyside/tests/test_serialization_roundtrip.py
@@ -14,6 +14,7 @@ from prototypyside.services.proto_registry import RootRegistry, ProtoRegistry
 
 # ── MODELS & HELPERS ───────────────────────────────────────────────────────
 from prototypyside.models.component_element import TextElement, ImageElement
+from prototypyside.models.vector_element import VectorElement
 from prototypyside.models.component_template import ComponentTemplate
 from prototypyside.models.layout_template import LayoutTemplate
 from prototypyside.models.layout_slot import LayoutSlot
@@ -90,6 +91,7 @@ def test_units_schema_and_roundtrip(name, instance, validator):
 MODEL_FACTORIES = [
     ("text_element",       lambda reg: TextElement(resolve_pid("te"), geometry=usg)),
     ("image_element",      lambda reg: ImageElement(resolve_pid("ie"), geometry=usg)),
+    ("vector_element",     lambda reg: VectorElement(resolve_pid("ve"), geometry=usg)),
     ("component_template", lambda reg: ComponentTemplate(resolve_pid("ct"), geometry=usg, registry=reg)),
     ("layout_template",    lambda reg: LayoutTemplate(resolve_pid("lt"), geometry=usg, registry=reg)),
     ("layout_slot",        lambda reg: LayoutSlot(resolve_pid("ls"), geometry=usg)),

--- a/prototypyside/utils/proto_helpers.py
+++ b/prototypyside/utils/proto_helpers.py
@@ -25,6 +25,7 @@ OBJECT_ONLY: Dict[str, str] = {
 REGISTERED: Dict[str, str] = {
     "ie": "ImageElement",
     "te": "TextElement",
+    "ve": "VectorElement",
     "ct": "ComponentTemplate",
     "cc": "Component",
     "lt": "LayoutTemplate",

--- a/prototypyside/utils/validator.py
+++ b/prototypyside/utils/validator.py
@@ -13,6 +13,7 @@ class SchemaValidator:
         "lt": "layout_template.json",
         "pg": "layout_template.json",
         "ie": "image_element.json",
+        "ve": "vector_element.json",
         "te": "text_element.json",
         "ls": "layout_slot.json",
     }

--- a/prototypyside/views/panels/property_panel.py
+++ b/prototypyside/views/panels/property_panel.py
@@ -12,6 +12,7 @@ from prototypyside.widgets.unit_field import UnitField, UnitStrGeometryField
 from prototypyside.utils.units.unit_str_geometry import UnitStrGeometry
 from prototypyside.models.component_element import ComponentElement
 from prototypyside.models.image_element import ImageElement
+from prototypyside.models.vector_element import VectorElement
 from prototypyside.models.text_element import TextElement
 from prototypyside.views.toolbars.font_toolbar import FontToolbar
 from prototypyside.widgets.color_picker import ColorPickerWidget
@@ -209,7 +210,7 @@ class PropertyPanel(QWidget):
         if isinstance(item, TextElement):
             self.content_text_edit.setText(item.content or "")
             self.content_stack.setCurrentWidget(self.content_text_edit)
-        elif isinstance(item, ImageElement):
+        elif isinstance(item, (ImageElement, VectorElement)):
             self.content_stack.setCurrentWidget(self.content_path_button)
         else:
              self.form_layout.labelForField(self.content_stack).hide()
@@ -283,7 +284,7 @@ class PropertyPanel(QWidget):
             self.content_stack.setCurrentWidget(self.content_text_edit)
             self.content_text_edit.setTarget(el, "content")
             self.content_text_edit.setText(el.content or "")
-        elif isinstance(el, ImageElement):
+        elif isinstance(el, (ImageElement, VectorElement)):
 
             self.content_stack.setCurrentWidget(self.content_path_button)
             self.content_stack.setMaximumHeight(20)
@@ -314,10 +315,10 @@ class PropertyPanel(QWidget):
  
     @Slot()
     def _choose_image_path(self):
-        if not isinstance(self.target_item, ImageElement):
+        if not isinstance(self.target_item, (ImageElement, VectorElement)):
             return
         file_path, _ = QFileDialog.getOpenFileName(
-            self, "Select Image", "", "Images (*.png *.jpg *.jpeg *.bmp *.gif)"
+            self, "Select File", "", "Images (*.png *.jpg *.bmp *.gif);;SVG Files (*.svg)"
         )
         if file_path:
             old_value = self.target_item.content

--- a/prototypyside/views/tabs/component_tab.py
+++ b/prototypyside/views/tabs/component_tab.py
@@ -184,6 +184,7 @@ class ComponentTab(QWidget):
         components = [
             ("Text Field", "te", "T"),
             ("Image Container", "ie", "🖼️"),
+            ("Vector Graphic", "ve", "⬠"),
         ]
         for name, etype, icon in components:
             item = QListWidgetItem(f"{icon} {name}")


### PR DESCRIPTION
## Summary
- implement `VectorElement` for SVG graphics
- register vector element prefix and factory mappings
- allow vector items in component schemas
- expose vector elements in the component tab palette
- support vector elements in property panel and export pipeline
- update tests and validator for new element

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_6883bd23f504832db56df401d8f76e37